### PR TITLE
- New branch that builds against develop (still requires some commits…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # are executed when this image "kbase/depl" is build. This is why this 
 # Dockerfile seems to be empty.
 
-FROM kbase/deplbase:latest
+FROM kbase/deplbase:develop
 MAINTAINER Shane Canon scanon@lbl.gov
 
 # Temporary hotfixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ aweworkerdev:
   restart: always
   links:
    - www:www
+  volumes:
+   - /var/run/docker.sock:/var/run/docker.sock
+   - /mnt/awe/dev/work:/mnt/awe/dev/work
   command: aweworker dev
 narrative:
   image: kbase/depl:latest

--- a/narrative/Dockerfile
+++ b/narrative/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/narrative:1.0.3
+FROM kbase/narrative:develop
 MAINTAINER Shane Canon scanon@lbl.gov
 
 USER root

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -48,6 +48,8 @@ server {
         #    proxy_set_header Host $http_host;
         #    proxy_set_header X-Forwarded-Proto $scheme;
         #}
+        #%BEGIN%
+        #%END%
  	location /services/ {
             proxy_pass http://router:5000/services/;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -122,6 +124,8 @@ server {
             #proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
+        #%BEGIN%
+        #%END%
  	location /services/ {
             proxy_pass http://router:5000/services/;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/generate_config
+++ b/scripts/generate_config
@@ -8,7 +8,7 @@ fi
 . ./site.cfg
 
 BASE=$(grep ^FROM Dockerfile|sed 's/FROM //')
-docker run --rm $BASE cat cluster.ini.docker | \
+docker run --rm $BASE cat /kb/deployment/deployment.cfg | \
 	sed "s/=kbaseuserid/=$USER/"| \
 	sed "s/=kbpassword/=$PASSWORD/"| \
 	sed "s/public.hostname.org/${PUBLIC_ADDRESS}/g" | \

--- a/scripts/setup_mongo
+++ b/scripts/setup_mongo
@@ -13,5 +13,5 @@ else
   fi
 
   export MONGO_HOST=mongo
-  /tmp/dt/config/setup_mongo
+  ./config/setup_mongo
 fi


### PR DESCRIPTION
… and changes for deplbase)
- Added volumes for aweworker to support runing docker containers
- Added template markers for proxy config
- small changes to generate_config and setup_mongo
